### PR TITLE
decouple witness solve and proof computation to allow pipeline

### DIFF
--- a/backend/groth16/bls12-381/prove.go
+++ b/backend/groth16/bls12-381/prove.go
@@ -43,6 +43,283 @@ func (proof *Proof) isValid() bool {
 	return proof.Ar.IsInSubGroup() && proof.Krs.IsInSubGroup() && proof.Bs.IsInSubGroup()
 }
 
+type SolveResult struct {
+	solution               *cs.R1CSSolution
+	proof                  *Proof // commitment
+	privateCommittedValues [][]fr.Element
+	commitmentInfo         constraint.Groth16Commitments
+	nbPublic               int
+}
+
+// Solve since this processing has a very-low cpu-usage in most circuits, we take it out of the backend.Prove so we can have a pipeline
+// i.e. Only Witness Generation
+func Solve(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...backend.ProverOption) (*SolveResult, error) {
+	opt, err := backend.NewProverConfig(opts...)
+	if err != nil {
+		return nil, fmt.Errorf("new prover config: %w", err)
+	}
+	if opt.HashToFieldFn == nil {
+		opt.HashToFieldFn = hash_to_field.New([]byte(constraint.CommitmentDst))
+	}
+
+	commitmentInfo := r1cs.CommitmentInfo.(constraint.Groth16Commitments)
+
+	proof := &Proof{Commitments: make([]curve.G1Affine, len(commitmentInfo))}
+
+	solverOpts := opt.SolverOpts[:len(opt.SolverOpts):len(opt.SolverOpts)]
+
+	privateCommittedValues := make([][]fr.Element, len(commitmentInfo))
+
+	// override hints
+	bsb22ID := solver.GetHintID(fcs.Bsb22CommitmentComputePlaceholder)
+	solverOpts = append(solverOpts, solver.OverrideHint(bsb22ID, func(_ *big.Int, in []*big.Int, out []*big.Int) error {
+		i := int(in[0].Int64())
+		in = in[1:]
+		privateCommittedValues[i] = make([]fr.Element, len(commitmentInfo[i].PrivateCommitted))
+		hashed := in[:len(commitmentInfo[i].PublicAndCommitmentCommitted)]
+		committed := in[+len(hashed):]
+		for j, inJ := range committed {
+			privateCommittedValues[i][j].SetBigInt(inJ)
+		}
+
+		var err error
+		if proof.Commitments[i], err = pk.CommitmentKeys[i].Commit(privateCommittedValues[i]); err != nil {
+			return err
+		}
+
+		opt.HashToFieldFn.Write(constraint.SerializeCommitment(proof.Commitments[i].Marshal(), hashed, (fr.Bits-1)/8+1))
+		hashBts := opt.HashToFieldFn.Sum(nil)
+		opt.HashToFieldFn.Reset()
+		nbBuf := fr.Bytes
+		if opt.HashToFieldFn.Size() < fr.Bytes {
+			nbBuf = opt.HashToFieldFn.Size()
+		}
+		var res fr.Element
+		res.SetBytes(hashBts[:nbBuf])
+		res.BigInt(out[0])
+		return nil
+	}))
+
+	_solution, err := r1cs.Solve(fullWitness, solverOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return &SolveResult{
+		solution:               _solution.(*cs.R1CSSolution),
+		proof:                  proof,
+		privateCommittedValues: privateCommittedValues,
+		commitmentInfo:         commitmentInfo,
+		nbPublic:               r1cs.GetNbPublicVariables(),
+	}, nil
+}
+
+// ProofComputing another pipeline processing, it has a high-usage of cpu and is fast
+// fft and msm
+func ProofComputing(solve *SolveResult, pk *ProvingKey) (*Proof, error) {
+	wireValues := []fr.Element(solve.solution.W)
+	proof := solve.proof
+	poks := make([]curve.G1Affine, len(pk.CommitmentKeys))
+	for i := range pk.CommitmentKeys {
+		var err error
+		if poks[i], err = pk.CommitmentKeys[i].ProveKnowledge(solve.privateCommittedValues[i]); err != nil {
+			return nil, err
+		}
+	}
+	// compute challenge for folding the PoKs from the commitments
+	commitmentsSerialized := make([]byte, fr.Bytes*len(solve.commitmentInfo))
+	for i := range solve.commitmentInfo {
+		copy(commitmentsSerialized[fr.Bytes*i:], wireValues[solve.commitmentInfo[i].CommitmentIndex].Marshal())
+	}
+	challenge, err := fr.Hash(commitmentsSerialized, []byte("G16-BSB22"), 1)
+	if err != nil {
+		return nil, err
+	}
+	if _, err = proof.CommitmentPok.Fold(poks, challenge[0], ecc.MultiExpConfig{NbTasks: 1}); err != nil {
+		return nil, err
+	}
+	// H (witness reduction / FFT part)
+	var h []fr.Element
+	chHDone := make(chan struct{}, 1)
+	go func() {
+		h = computeH(solve.solution.A, solve.solution.B, solve.solution.C, &pk.Domain)
+		solve.solution.A = nil
+		solve.solution.B = nil
+		solve.solution.C = nil
+		chHDone <- struct{}{}
+	}()
+
+	// we need to copy and filter the wireValues for each multi exp
+	// as pk.G1.A, pk.G1.B and pk.G2.B may have (a significant) number of point at infinity
+	var wireValuesA, wireValuesB []fr.Element
+	chWireValuesA, chWireValuesB := make(chan struct{}, 1), make(chan struct{}, 1)
+
+	go func() {
+		wireValuesA = make([]fr.Element, len(wireValues)-int(pk.NbInfinityA))
+		for i, j := 0, 0; j < len(wireValuesA); i++ {
+			if pk.InfinityA[i] {
+				continue
+			}
+			wireValuesA[j] = wireValues[i]
+			j++
+		}
+		close(chWireValuesA)
+	}()
+	go func() {
+		wireValuesB = make([]fr.Element, len(wireValues)-int(pk.NbInfinityB))
+		for i, j := 0, 0; j < len(wireValuesB); i++ {
+			if pk.InfinityB[i] {
+				continue
+			}
+			wireValuesB[j] = wireValues[i]
+			j++
+		}
+		close(chWireValuesB)
+	}()
+
+	// sample random r and s
+	var r, s big.Int
+	var _r, _s, _kr fr.Element
+	if _, err := _r.SetRandom(); err != nil {
+		return nil, err
+	}
+	if _, err := _s.SetRandom(); err != nil {
+		return nil, err
+	}
+	_kr.Mul(&_r, &_s).Neg(&_kr)
+
+	_r.BigInt(&r)
+	_s.BigInt(&s)
+
+	// computes r[δ], s[δ], kr[δ]
+	deltas := curve.BatchScalarMultiplicationG1(&pk.G1.Delta, []fr.Element{_r, _s, _kr})
+
+	var bs1, ar curve.G1Jac
+
+	n := runtime.NumCPU()
+
+	chBs1Done := make(chan error, 1)
+	computeBS1 := func() {
+		<-chWireValuesB
+		if _, err := bs1.MultiExp(pk.G1.B, wireValuesB, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
+			chBs1Done <- err
+			close(chBs1Done)
+			return
+		}
+		bs1.AddMixed(&pk.G1.Beta)
+		bs1.AddMixed(&deltas[1])
+		chBs1Done <- nil
+	}
+
+	chArDone := make(chan error, 1)
+	computeAR1 := func() {
+		<-chWireValuesA
+		if _, err := ar.MultiExp(pk.G1.A, wireValuesA, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
+			chArDone <- err
+			close(chArDone)
+			return
+		}
+		ar.AddMixed(&pk.G1.Alpha)
+		ar.AddMixed(&deltas[0])
+		proof.Ar.FromJacobian(&ar)
+		chArDone <- nil
+	}
+
+	chKrsDone := make(chan error, 1)
+	computeKRS := func() {
+		// we could NOT split the Krs multiExp in 2, and just append pk.G1.K and pk.G1.Z
+		// however, having similar lengths for our tasks helps with parallelism
+
+		var krs, krs2, p1 curve.G1Jac
+		chKrs2Done := make(chan error, 1)
+		sizeH := int(pk.Domain.Cardinality - 1) // comes from the fact the deg(H)=(n-1)+(n-1)-n=n-2
+		go func() {
+			_, err := krs2.MultiExp(pk.G1.Z, h[:sizeH], ecc.MultiExpConfig{NbTasks: n / 2})
+			chKrs2Done <- err
+		}()
+
+		// filter the wire values if needed
+		// TODO Perf @Tabaie worst memory allocation offender
+		toRemove := solve.commitmentInfo.GetPrivateCommitted()
+		toRemove = append(toRemove, solve.commitmentInfo.CommitmentIndexes())
+		_wireValues := filterHeap(wireValues[solve.nbPublic:], solve.nbPublic, internal.ConcatAll(toRemove...))
+
+		if _, err := krs.MultiExp(pk.G1.K, _wireValues, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
+			chKrsDone <- err
+			return
+		}
+		krs.AddMixed(&deltas[2])
+		n := 3
+		for n != 0 {
+			select {
+			case err := <-chKrs2Done:
+				if err != nil {
+					chKrsDone <- err
+					return
+				}
+				krs.AddAssign(&krs2)
+			case err := <-chArDone:
+				if err != nil {
+					chKrsDone <- err
+					return
+				}
+				p1.ScalarMultiplication(&ar, &s)
+				krs.AddAssign(&p1)
+			case err := <-chBs1Done:
+				if err != nil {
+					chKrsDone <- err
+					return
+				}
+				p1.ScalarMultiplication(&bs1, &r)
+				krs.AddAssign(&p1)
+			}
+			n--
+		}
+
+		proof.Krs.FromJacobian(&krs)
+		chKrsDone <- nil
+	}
+
+	computeBS2 := func() error {
+		// Bs2 (1 multi exp G2 - size = len(wires))
+		var Bs, deltaS curve.G2Jac
+
+		nbTasks := n
+		if nbTasks <= 16 {
+			// if we don't have a lot of CPUs, this may artificially split the MSM
+			nbTasks *= 2
+		}
+		<-chWireValuesB
+		if _, err := Bs.MultiExp(pk.G2.B, wireValuesB, ecc.MultiExpConfig{NbTasks: nbTasks}); err != nil {
+			return err
+		}
+
+		deltaS.FromAffine(&pk.G2.Delta)
+		deltaS.ScalarMultiplication(&deltaS, &s)
+		Bs.AddAssign(&deltaS)
+		Bs.AddMixed(&pk.G2.Beta)
+
+		proof.Bs.FromJacobian(&Bs)
+		return nil
+	}
+
+	// wait for FFT to end, as it uses all our CPUs
+	<-chHDone
+
+	// schedule our proof part computations
+	go computeKRS()
+	go computeAR1()
+	go computeBS1()
+	if err := computeBS2(); err != nil {
+		return nil, err
+	}
+
+	// wait for all parts of the proof to be computed.
+	if err := <-chKrsDone; err != nil {
+		return nil, err
+	}
+	return proof, nil
+}
+
 // CurveID returns the curveID
 func (proof *Proof) CurveID() ecc.ID {
 	return curve.ID

--- a/backend/groth16/bls12-381/prove.go
+++ b/backend/groth16/bls12-381/prove.go
@@ -55,6 +55,7 @@ type SolveResult struct {
 // i.e. Only Witness Generation
 func Solve(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...backend.ProverOption) (*SolveResult, error) {
 	opt, err := backend.NewProverConfig(opts...)
+	log := logger.Logger().With().Str("curve", r1cs.CurveID().String()).Str("acceleration", "none").Int("nbConstraints", r1cs.GetNbConstraints()).Str("backend", "groth16").Logger()
 	if err != nil {
 		return nil, fmt.Errorf("new prover config: %w", err)
 	}
@@ -99,8 +100,10 @@ func Solve(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 		res.BigInt(out[0])
 		return nil
 	}))
-
+	start := time.Now()
 	_solution, err := r1cs.Solve(fullWitness, solverOpts...)
+	log.Debug().Dur("took", time.Since(start)).Msg("solver done")
+
 	if err != nil {
 		return nil, err
 	}
@@ -116,6 +119,8 @@ func Solve(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 // ProofComputing another pipeline processing, it has a high-usage of cpu and is fast
 // fft and msm
 func ProofComputing(solve *SolveResult, pk *ProvingKey) (*Proof, error) {
+	log := logger.Logger().With().Str("curve", pk.CurveID().String()).Str("acceleration", "none").Int("nbCommitmentInfo", len(solve.commitmentInfo)).Int("nbPublic", solve.nbPublic).Int("nbPrivateCommittedValues", len(solve.privateCommittedValues)).Str("backend", "groth16").Logger()
+	start := time.Now()
 	wireValues := []fr.Element(solve.solution.W)
 	proof := solve.proof
 	poks := make([]curve.G1Affine, len(pk.CommitmentKeys))
@@ -317,6 +322,8 @@ func ProofComputing(solve *SolveResult, pk *ProvingKey) (*Proof, error) {
 	if err := <-chKrsDone; err != nil {
 		return nil, err
 	}
+	log.Debug().Dur("took", time.Since(start)).Msg("prover done")
+
 	return proof, nil
 }
 

--- a/backend/groth16/groth16.go
+++ b/backend/groth16/groth16.go
@@ -9,6 +9,7 @@
 package groth16
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/consensys/gnark-crypto/ecc"
@@ -166,6 +167,54 @@ func Verify(proof Proof, vk VerifyingKey, publicWitness witness.Witness, opts ..
 			return witness.ErrInvalidWitness
 		}
 		return groth16_bw6633.Verify(_proof, vk.(*groth16_bw6633.VerifyingKey), w, opts...)
+	default:
+		panic("unrecognized R1CS curve type")
+	}
+}
+
+func Solve(r1cs constraint.ConstraintSystem, pk ProvingKey, fullWitness witness.Witness, opts ...backend.ProverOption) (any, error) {
+	switch _r1cs := r1cs.(type) {
+	case *cs_bls12377.R1CS:
+		return groth16_bls12377.Solve(_r1cs, pk.(*groth16_bls12377.ProvingKey), fullWitness, opts...)
+	case *cs_bls12381.R1CS:
+		return groth16_bls12381.Solve(_r1cs, pk.(*groth16_bls12381.ProvingKey), fullWitness, opts...)
+	case *cs_bn254.R1CS:
+		if icicle_bn254.HasIcicle {
+			return nil, fmt.Errorf("bn254 icicle has not impl solve")
+		}
+		return groth16_bn254.Solve(_r1cs, pk.(*groth16_bn254.ProvingKey), fullWitness, opts...)
+	case *cs_bw6761.R1CS:
+		return groth16_bw6761.Solve(_r1cs, pk.(*groth16_bw6761.ProvingKey), fullWitness, opts...)
+	case *cs_bls24317.R1CS:
+		return groth16_bls24317.Solve(_r1cs, pk.(*groth16_bls24317.ProvingKey), fullWitness, opts...)
+	case *cs_bls24315.R1CS:
+		return groth16_bls24315.Solve(_r1cs, pk.(*groth16_bls24315.ProvingKey), fullWitness, opts...)
+	case *cs_bw6633.R1CS:
+		return groth16_bw6633.Solve(_r1cs, pk.(*groth16_bw6633.ProvingKey), fullWitness, opts...)
+	default:
+		panic("unrecognized R1CS curve type")
+	}
+}
+
+func ProofComputing(solveResult any, pk ProvingKey) (Proof, error) {
+	switch solveResult.(type) {
+	case *groth16_bls12377.SolveResult:
+		return groth16_bls12377.ProofComputing(solveResult.(*groth16_bls12377.SolveResult), pk.(*groth16_bls12377.ProvingKey))
+	case *groth16_bls12381.SolveResult:
+		return groth16_bls12381.ProofComputing(solveResult.(*groth16_bls12381.SolveResult), pk.(*groth16_bls12381.ProvingKey))
+	case *groth16_bn254.SolveResult:
+		if icicle_bn254.HasIcicle {
+			return nil, fmt.Errorf("bn254 icicle has not impl solve")
+		}
+		return groth16_bn254.ProofComputing(solveResult.(*groth16_bn254.SolveResult), pk.(*groth16_bn254.ProvingKey))
+	case *groth16_bw6761.SolveResult:
+		return groth16_bw6761.ProofComputing(solveResult.(*groth16_bw6761.SolveResult), pk.(*groth16_bw6761.ProvingKey))
+	case *groth16_bls24317.SolveResult:
+		return groth16_bls24317.ProofComputing(solveResult.(*groth16_bls24317.SolveResult), pk.(*groth16_bls24317.ProvingKey))
+	case *groth16_bls24315.SolveResult:
+		return groth16_bls24315.ProofComputing(solveResult.(*groth16_bls24315.SolveResult), pk.(*groth16_bls24315.ProvingKey))
+	case *groth16_bw6633.SolveResult:
+		return groth16_bw6633.ProofComputing(solveResult.(*groth16_bw6633.SolveResult), pk.(*groth16_bw6633.ProvingKey))
 	default:
 		panic("unrecognized R1CS curve type")
 	}


### PR DESCRIPTION
Decoupled the groth16.Prove function and decomposed it into Solve and ProofComputing functions, where the Solve function is used to calculate the solution of r1cs obtained from the witness generation process, and the ProofComputing is used to calculate the FFT and MSM processes to obtain groth16.Proof. The purpose is to optimize these two processes in a pipeline, accelerate and improve system resource utilization. This feature has been partially adapted for all curve CPUs currently supported by gnark (except for the ICICLE of BN254, which is used for GPUs).