### PR TITLE
N3 contract export

### DIFF
--- a/backend/groth16/bls12-377/verify.go
+++ b/backend/groth16/bls12-377/verify.go
@@ -133,3 +133,7 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }
+
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/groth16/bls12-381/prove.go
+++ b/backend/groth16/bls12-381/prove.go
@@ -43,6 +43,283 @@ func (proof *Proof) isValid() bool {
 	return proof.Ar.IsInSubGroup() && proof.Krs.IsInSubGroup() && proof.Bs.IsInSubGroup()
 }
 
+type SolveResult struct {
+	solution               *cs.R1CSSolution
+	proof                  *Proof // commitment
+	privateCommittedValues [][]fr.Element
+	commitmentInfo         constraint.Groth16Commitments
+	nbPublic               int
+}
+
+// Solve since this processing has a very-low cpu-usage in most circuits, we take it out of the backend.Prove so we can have a pipeline
+// i.e. Only Witness Generation
+func Solve(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...backend.ProverOption) (*SolveResult, error) {
+	opt, err := backend.NewProverConfig(opts...)
+	if err != nil {
+		return nil, fmt.Errorf("new prover config: %w", err)
+	}
+	if opt.HashToFieldFn == nil {
+		opt.HashToFieldFn = hash_to_field.New([]byte(constraint.CommitmentDst))
+	}
+
+	commitmentInfo := r1cs.CommitmentInfo.(constraint.Groth16Commitments)
+
+	proof := &Proof{Commitments: make([]curve.G1Affine, len(commitmentInfo))}
+
+	solverOpts := opt.SolverOpts[:len(opt.SolverOpts):len(opt.SolverOpts)]
+
+	privateCommittedValues := make([][]fr.Element, len(commitmentInfo))
+
+	// override hints
+	bsb22ID := solver.GetHintID(fcs.Bsb22CommitmentComputePlaceholder)
+	solverOpts = append(solverOpts, solver.OverrideHint(bsb22ID, func(_ *big.Int, in []*big.Int, out []*big.Int) error {
+		i := int(in[0].Int64())
+		in = in[1:]
+		privateCommittedValues[i] = make([]fr.Element, len(commitmentInfo[i].PrivateCommitted))
+		hashed := in[:len(commitmentInfo[i].PublicAndCommitmentCommitted)]
+		committed := in[+len(hashed):]
+		for j, inJ := range committed {
+			privateCommittedValues[i][j].SetBigInt(inJ)
+		}
+
+		var err error
+		if proof.Commitments[i], err = pk.CommitmentKeys[i].Commit(privateCommittedValues[i]); err != nil {
+			return err
+		}
+
+		opt.HashToFieldFn.Write(constraint.SerializeCommitment(proof.Commitments[i].Marshal(), hashed, (fr.Bits-1)/8+1))
+		hashBts := opt.HashToFieldFn.Sum(nil)
+		opt.HashToFieldFn.Reset()
+		nbBuf := fr.Bytes
+		if opt.HashToFieldFn.Size() < fr.Bytes {
+			nbBuf = opt.HashToFieldFn.Size()
+		}
+		var res fr.Element
+		res.SetBytes(hashBts[:nbBuf])
+		res.BigInt(out[0])
+		return nil
+	}))
+
+	_solution, err := r1cs.Solve(fullWitness, solverOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return &SolveResult{
+		solution:               _solution.(*cs.R1CSSolution),
+		proof:                  proof,
+		privateCommittedValues: privateCommittedValues,
+		commitmentInfo:         commitmentInfo,
+		nbPublic:               r1cs.GetNbPublicVariables(),
+	}, nil
+}
+
+// ProofComputing another pipeline processing, it has a high-usage of cpu and is fast
+// fft and msm
+func ProofComputing(solve *SolveResult, pk *ProvingKey) (*Proof, error) {
+	wireValues := []fr.Element(solve.solution.W)
+	proof := solve.proof
+	poks := make([]curve.G1Affine, len(pk.CommitmentKeys))
+	for i := range pk.CommitmentKeys {
+		var err error
+		if poks[i], err = pk.CommitmentKeys[i].ProveKnowledge(solve.privateCommittedValues[i]); err != nil {
+			return nil, err
+		}
+	}
+	// compute challenge for folding the PoKs from the commitments
+	commitmentsSerialized := make([]byte, fr.Bytes*len(solve.commitmentInfo))
+	for i := range solve.commitmentInfo {
+		copy(commitmentsSerialized[fr.Bytes*i:], wireValues[solve.commitmentInfo[i].CommitmentIndex].Marshal())
+	}
+	challenge, err := fr.Hash(commitmentsSerialized, []byte("G16-BSB22"), 1)
+	if err != nil {
+		return nil, err
+	}
+	if _, err = proof.CommitmentPok.Fold(poks, challenge[0], ecc.MultiExpConfig{NbTasks: 1}); err != nil {
+		return nil, err
+	}
+	// H (witness reduction / FFT part)
+	var h []fr.Element
+	chHDone := make(chan struct{}, 1)
+	go func() {
+		h = computeH(solve.solution.A, solve.solution.B, solve.solution.C, &pk.Domain)
+		solve.solution.A = nil
+		solve.solution.B = nil
+		solve.solution.C = nil
+		chHDone <- struct{}{}
+	}()
+
+	// we need to copy and filter the wireValues for each multi exp
+	// as pk.G1.A, pk.G1.B and pk.G2.B may have (a significant) number of point at infinity
+	var wireValuesA, wireValuesB []fr.Element
+	chWireValuesA, chWireValuesB := make(chan struct{}, 1), make(chan struct{}, 1)
+
+	go func() {
+		wireValuesA = make([]fr.Element, len(wireValues)-int(pk.NbInfinityA))
+		for i, j := 0, 0; j < len(wireValuesA); i++ {
+			if pk.InfinityA[i] {
+				continue
+			}
+			wireValuesA[j] = wireValues[i]
+			j++
+		}
+		close(chWireValuesA)
+	}()
+	go func() {
+		wireValuesB = make([]fr.Element, len(wireValues)-int(pk.NbInfinityB))
+		for i, j := 0, 0; j < len(wireValuesB); i++ {
+			if pk.InfinityB[i] {
+				continue
+			}
+			wireValuesB[j] = wireValues[i]
+			j++
+		}
+		close(chWireValuesB)
+	}()
+
+	// sample random r and s
+	var r, s big.Int
+	var _r, _s, _kr fr.Element
+	if _, err := _r.SetRandom(); err != nil {
+		return nil, err
+	}
+	if _, err := _s.SetRandom(); err != nil {
+		return nil, err
+	}
+	_kr.Mul(&_r, &_s).Neg(&_kr)
+
+	_r.BigInt(&r)
+	_s.BigInt(&s)
+
+	// computes r[δ], s[δ], kr[δ]
+	deltas := curve.BatchScalarMultiplicationG1(&pk.G1.Delta, []fr.Element{_r, _s, _kr})
+
+	var bs1, ar curve.G1Jac
+
+	n := runtime.NumCPU()
+
+	chBs1Done := make(chan error, 1)
+	computeBS1 := func() {
+		<-chWireValuesB
+		if _, err := bs1.MultiExp(pk.G1.B, wireValuesB, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
+			chBs1Done <- err
+			close(chBs1Done)
+			return
+		}
+		bs1.AddMixed(&pk.G1.Beta)
+		bs1.AddMixed(&deltas[1])
+		chBs1Done <- nil
+	}
+
+	chArDone := make(chan error, 1)
+	computeAR1 := func() {
+		<-chWireValuesA
+		if _, err := ar.MultiExp(pk.G1.A, wireValuesA, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
+			chArDone <- err
+			close(chArDone)
+			return
+		}
+		ar.AddMixed(&pk.G1.Alpha)
+		ar.AddMixed(&deltas[0])
+		proof.Ar.FromJacobian(&ar)
+		chArDone <- nil
+	}
+
+	chKrsDone := make(chan error, 1)
+	computeKRS := func() {
+		// we could NOT split the Krs multiExp in 2, and just append pk.G1.K and pk.G1.Z
+		// however, having similar lengths for our tasks helps with parallelism
+
+		var krs, krs2, p1 curve.G1Jac
+		chKrs2Done := make(chan error, 1)
+		sizeH := int(pk.Domain.Cardinality - 1) // comes from the fact the deg(H)=(n-1)+(n-1)-n=n-2
+		go func() {
+			_, err := krs2.MultiExp(pk.G1.Z, h[:sizeH], ecc.MultiExpConfig{NbTasks: n / 2})
+			chKrs2Done <- err
+		}()
+
+		// filter the wire values if needed
+		// TODO Perf @Tabaie worst memory allocation offender
+		toRemove := solve.commitmentInfo.GetPrivateCommitted()
+		toRemove = append(toRemove, solve.commitmentInfo.CommitmentIndexes())
+		_wireValues := filterHeap(wireValues[solve.nbPublic:], solve.nbPublic, internal.ConcatAll(toRemove...))
+
+		if _, err := krs.MultiExp(pk.G1.K, _wireValues, ecc.MultiExpConfig{NbTasks: n / 2}); err != nil {
+			chKrsDone <- err
+			return
+		}
+		krs.AddMixed(&deltas[2])
+		n := 3
+		for n != 0 {
+			select {
+			case err := <-chKrs2Done:
+				if err != nil {
+					chKrsDone <- err
+					return
+				}
+				krs.AddAssign(&krs2)
+			case err := <-chArDone:
+				if err != nil {
+					chKrsDone <- err
+					return
+				}
+				p1.ScalarMultiplication(&ar, &s)
+				krs.AddAssign(&p1)
+			case err := <-chBs1Done:
+				if err != nil {
+					chKrsDone <- err
+					return
+				}
+				p1.ScalarMultiplication(&bs1, &r)
+				krs.AddAssign(&p1)
+			}
+			n--
+		}
+
+		proof.Krs.FromJacobian(&krs)
+		chKrsDone <- nil
+	}
+
+	computeBS2 := func() error {
+		// Bs2 (1 multi exp G2 - size = len(wires))
+		var Bs, deltaS curve.G2Jac
+
+		nbTasks := n
+		if nbTasks <= 16 {
+			// if we don't have a lot of CPUs, this may artificially split the MSM
+			nbTasks *= 2
+		}
+		<-chWireValuesB
+		if _, err := Bs.MultiExp(pk.G2.B, wireValuesB, ecc.MultiExpConfig{NbTasks: nbTasks}); err != nil {
+			return err
+		}
+
+		deltaS.FromAffine(&pk.G2.Delta)
+		deltaS.ScalarMultiplication(&deltaS, &s)
+		Bs.AddAssign(&deltaS)
+		Bs.AddMixed(&pk.G2.Beta)
+
+		proof.Bs.FromJacobian(&Bs)
+		return nil
+	}
+
+	// wait for FFT to end, as it uses all our CPUs
+	<-chHDone
+
+	// schedule our proof part computations
+	go computeKRS()
+	go computeAR1()
+	go computeBS1()
+	if err := computeBS2(); err != nil {
+		return nil, err
+	}
+
+	// wait for all parts of the proof to be computed.
+	if err := <-chKrsDone; err != nil {
+		return nil, err
+	}
+	return proof, nil
+}
+
 // CurveID returns the curveID
 func (proof *Proof) CurveID() ecc.ID {
 	return curve.ID

--- a/backend/groth16/bls12-381/prove.go
+++ b/backend/groth16/bls12-381/prove.go
@@ -55,6 +55,7 @@ type SolveResult struct {
 // i.e. Only Witness Generation
 func Solve(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...backend.ProverOption) (*SolveResult, error) {
 	opt, err := backend.NewProverConfig(opts...)
+	log := logger.Logger().With().Str("curve", r1cs.CurveID().String()).Str("acceleration", "none").Int("nbConstraints", r1cs.GetNbConstraints()).Str("backend", "groth16").Logger()
 	if err != nil {
 		return nil, fmt.Errorf("new prover config: %w", err)
 	}
@@ -99,8 +100,10 @@ func Solve(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 		res.BigInt(out[0])
 		return nil
 	}))
-
+	start := time.Now()
 	_solution, err := r1cs.Solve(fullWitness, solverOpts...)
+	log.Debug().Dur("took", time.Since(start)).Msg("solver done")
+
 	if err != nil {
 		return nil, err
 	}
@@ -116,6 +119,8 @@ func Solve(r1cs *cs.R1CS, pk *ProvingKey, fullWitness witness.Witness, opts ...b
 // ProofComputing another pipeline processing, it has a high-usage of cpu and is fast
 // fft and msm
 func ProofComputing(solve *SolveResult, pk *ProvingKey) (*Proof, error) {
+	log := logger.Logger().With().Str("curve", pk.CurveID().String()).Str("acceleration", "none").Int("nbCommitmentInfo", len(solve.commitmentInfo)).Int("nbPublic", solve.nbPublic).Int("nbPrivateCommittedValues", len(solve.privateCommittedValues)).Str("backend", "groth16").Logger()
+	start := time.Now()
 	wireValues := []fr.Element(solve.solution.W)
 	proof := solve.proof
 	poks := make([]curve.G1Affine, len(pk.CommitmentKeys))
@@ -317,6 +322,8 @@ func ProofComputing(solve *SolveResult, pk *ProvingKey) (*Proof, error) {
 	if err := <-chKrsDone; err != nil {
 		return nil, err
 	}
+	log.Debug().Dur("took", time.Since(start)).Msg("prover done")
+
 	return proof, nil
 }
 

--- a/backend/groth16/bls12-381/verify.go
+++ b/backend/groth16/bls12-381/verify.go
@@ -133,3 +133,7 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }
+
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/groth16/bls24-315/verify.go
+++ b/backend/groth16/bls24-315/verify.go
@@ -133,3 +133,6 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/groth16/bls24-317/verify.go
+++ b/backend/groth16/bls24-317/verify.go
@@ -133,3 +133,6 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/groth16/bn254/n3_contract.go
+++ b/backend/groth16/bn254/n3_contract.go
@@ -1,0 +1,412 @@
+package groth16
+
+import (
+	"bytes"
+	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
+)
+
+const n3ContractTemplate = `
+{{- $numPublic := sub (len .Vk.G1.K) 1 }}
+{{- $numCommitments := len .Vk.PublicAndCommitmentCommitted }}
+{{- $numWitness := sub $numPublic $numCommitments }}
+{{- $PublicAndCommitmentCommitted := .Vk.PublicAndCommitmentCommitted }}
+using Neo.SmartContract.Framework.Attributes;
+using System;
+using System.ComponentModel;
+using System.Numerics;
+using Neo.SmartContract.Framework;
+
+namespace Neo.Compiler.CSharp.TestContracts	
+{
+    [DisplayName("ZkpVerifyContract")]
+    public class ZkpVerifyContract : SmartContract.Framework.SmartContract
+    {
+        static readonly string PublicInputNotInField = "PublicInputNotInField";
+        static readonly string ProofInvalid = "ProofInvalid";
+        static readonly string CommitmentInvalid = "CommitmentInvalid";
+
+        static readonly BigInteger PRECOMPILE_MODEXP = 0x05;
+        static readonly BigInteger PRECOMPILE_ADD = 0x06;
+        static readonly BigInteger PRECOMPILE_MUL = 0x07;
+        static readonly BigInteger PRECOMPILE_VERIFY = 0x08;
+
+ 		// Base field Fp order P and scalar field Fr order R.
+        // For BN254 these are computed as follows:
+        //     t = 4965661367192848881
+        //     P = 36⋅t⁴ + 36⋅t³ + 24⋅t² + 6⋅t + 1
+        //     R = 36⋅t⁴ + 36⋅t³ + 18⋅t² + 6⋅t + 1
+        static readonly BigInteger P =  BigInteger.Parse("21888242871839275222246405745257275088696311157297823662689037894645226208583");//0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47
+        static readonly BigInteger R = BigInteger.Parse("21888242871839275222246405745257275088548364400416034343698204186575808495617");//0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001
+
+		// Extension field Fp2 = Fp[i] / (i² + 1)
+        // Note: This is the complex extension field of Fp with i² = -1.
+        //       Values in Fp2 are represented as a pair of Fp elements (a₀, a₁) as a₀ + a₁⋅i.
+        // Note: The order of Fp2 elements is *opposite* that of the pairing contract, which
+        //       expects Fp2 elements in order (a₁, a₀). This is also the order in which
+        //       Fp2 elements are encoded in the public interface as this became convention.
+
+        // Constants in Fp
+        static readonly BigInteger FRACTION_1_2_FP = BigInteger.Parse("10944121435919637611123202872628637544348155578648911831344518947322613104292");//0x183227397098d014dc2822db40c0ac2ecbc0b548b438e5469e10460b6c3e7ea4
+        static readonly BigInteger FRACTION_27_82_FP = BigInteger.Parse("19485874751759354771024239261021720505790618469301721065564631296452457478373");//0x2b149d40ceb8aaae81be18991be06ac3b5b4c5e559dbefa33267e6dc24a138e5
+        static readonly BigInteger FRACTION_3_82_FP = BigInteger.Parse("21621313080719284060999498358119991246151234191964923374119659383734918571893");//0x2fcd3ac2a640a154eb23960892a85a68f031ca0c8344b23a577dcf1052b9e775
+
+        // Exponents for inversions and square roots mod P
+        static readonly BigInteger EXP_INVERSE_FP = BigInteger.Parse("21888242871839275222246405745257275088696311157297823662689037894645226208581"); // P - 2//0x30644E72E131A029B85045B68181585D97816A916871CA8D3C208C16D87CFD45
+        static readonly BigInteger EXP_SQRT_FP = BigInteger.Parse("5472060717959818805561601436314318772174077789324455915672259473661306552146"); // (P + 1) / 4;//0xC19139CB84C680A6E14116DA060561765E05AA45A1C72A34F082305B61F3F52
+
+      	// Automatically filled and generated
+		
+		// Groth16 alpha point in G1
+        static readonly BigInteger ALPHA_X = BigInteger.Parse("{{ (fpstr .Vk.G1.Alpha.X) }}");
+        static readonly BigInteger ALPHA_Y = BigInteger.Parse("{{ (fpstr .Vk.G1.Alpha.Y) }} ");
+
+		// Groth16 alpha point in G2 in powers of i 
+        static readonly BigInteger BETA_NEG_X_0 = BigInteger.Parse("{{ (fpstr .Vk.G2.Beta.X.A0) }}");
+        static readonly BigInteger BETA_NEG_X_1 = BigInteger.Parse("{{ (fpstr .Vk.G2.Beta.X.A1) }}");
+        static readonly BigInteger BETA_NEG_Y_0 = BigInteger.Parse("{{ (fpstr .Vk.G2.Beta.Y.A0) }}");
+        static readonly BigInteger BETA_NEG_Y_1 = BigInteger.Parse("{{ (fpstr .Vk.G2.Beta.Y.A1) }}");
+
+    	// Groth16 gamma point in G2 in powers of i
+        static readonly BigInteger GAMMA_NEG_X_0 = BigInteger.Parse("{{ (fpstr .Vk.G2.Gamma.X.A0) }}");
+        static readonly BigInteger GAMMA_NEG_X_1 = BigInteger.Parse("{{ (fpstr .Vk.G2.Gamma.X.A1) }}");
+        static readonly BigInteger GAMMA_NEG_Y_0 = BigInteger.Parse("{{ (fpstr .Vk.G2.Gamma.Y.A0) }}");
+        static readonly BigInteger GAMMA_NEG_Y_1 = BigInteger.Parse("{{ (fpstr .Vk.G2.Gamma.Y.A1) }}");
+
+    	// Groth16 delta point in G2 in powers of i
+        static readonly BigInteger DELTA_NEG_X_0 = BigInteger.Parse("{{ (fpstr .Vk.G2.Delta.X.A0) }}");
+        static readonly BigInteger DELTA_NEG_X_1 = BigInteger.Parse("{{ (fpstr .Vk.G2.Delta.X.A1) }}");
+        static readonly BigInteger DELTA_NEG_Y_0 = BigInteger.Parse("{{ (fpstr .Vk.G2.Delta.Y.A0) }}");
+        static readonly BigInteger DELTA_NEG_Y_1 = BigInteger.Parse("{{ (fpstr .Vk.G2.Delta.Y.A1) }}");
+
+        {{- if gt $numCommitments 0 }}
+    	// Pedersen G point in G2 in powers of i
+    	{{- $cmtVk0 := index .Vk.CommitmentKeys 0 }}
+        static readonly BigInteger PEDERSEN_G_X_0 = BigInteger.Parse("{{ (fpstr $cmtVk0.G.X.A0) }}");
+        static readonly BigInteger PEDERSEN_G_X_1 = BigInteger.Parse("{{ (fpstr $cmtVk0.G.X.A1) }}");
+        static readonly BigInteger PEDERSEN_G_Y_0 = BigInteger.Parse("{{ (fpstr $cmtVk0.G.Y.A0) }}");
+        static readonly BigInteger PEDERSEN_G_Y_1 = BigInteger.Parse("{{ (fpstr $cmtVk0.G.Y.A1) }}");
+
+    	// Pedersen GSigmaNeg point in G2 in powers of i
+        static readonly BigInteger PEDERSEN_GSIGMANEG_X_0 = BigInteger.Parse("{{ (fpstr $cmtVk0.GSigmaNeg.X.A0) }}");
+        static readonly BigInteger PEDERSEN_GSIGMANEG_X_1 = BigInteger.Parse("{{ (fpstr $cmtVk0.GSigmaNeg.X.A1) }}");
+        static readonly BigInteger PEDERSEN_GSIGMANEG_Y_0 = BigInteger.Parse("{{ (fpstr $cmtVk0.GSigmaNeg.Y.A0) }}");
+        static readonly BigInteger PEDERSEN_GSIGMANEG_Y_1 = BigInteger.Parse("{{ (fpstr $cmtVk0.GSigmaNeg.Y.A1) }}");
+        {{ end }}
+
+        // Constant and public input points
+    	{{- $k0 := index .Vk.G1.K 0}}
+        static readonly BigInteger CONSTANT_X = BigInteger.Parse("{{ (fpstr $k0.X) }}");
+        static readonly BigInteger CONSTANT_Y = BigInteger.Parse("{{ (fpstr $k0.Y) }}");
+
+        {{- range $i, $ki := .Vk.G1.K }}
+        	{{- if gt $i 0 }}
+        static readonly BigInteger PUB_{{sub $i 1}}_X = BigInteger.Parse("{{ (fpstr $ki.X) }}");
+        static readonly BigInteger PUB_{{sub $i 1}}_Y = BigInteger.Parse("{{ (fpstr $ki.Y) }}");
+            {{- end }}
+    	{{- end }}
+
+        /// Negation in Fp.
+        /// @notice Returns a number x such that a + x = 0 in Fp.
+        /// @notice The input does not need to be reduced.
+        /// @param a the base
+        /// @return x the result
+        [Safe]
+        public static BigInteger Negate(BigInteger a)
+        {
+            unchecked
+            {
+                return (P - (a % P)) % P;
+            }
+        }
+
+        /// Exponentiation in Fp.
+        /// @notice Returns a number x such that a ^ e = x in Fp.
+        /// @notice The input does not need to be reduced.
+        /// @param a the base
+        /// @param e the exponent
+        /// @return x the result
+        [Safe]
+        public static BigInteger Exp(BigInteger a, BigInteger e)
+        {
+            return BigInteger.ModPow(a, e, P);
+        }
+
+        /// Exponentiation in Fp.
+        /// @notice Returns a number x such that a*b = x in Fp.
+        /// @notice The input does not need to be reduced.
+        /// @param a the mul number 1
+        /// @param b the mul number 2
+        /// @return x the result
+        [Safe]
+        public static BigInteger MulMod(BigInteger a, BigInteger b, BigInteger p)
+        {
+            return a.ModMultiply(b, p);
+        }
+
+        /// Exponentiation in Fp.
+        /// @notice Returns a number x such that a*b = x in Fp.
+        /// @notice The input does not need to be reduced.
+        /// @param a the add number 1
+        /// @param b the add number 2
+        /// @return x the result
+        [Safe]
+        public static BigInteger AddMod(BigInteger a, BigInteger b, BigInteger p)
+        {
+            return (a + b) % p;
+        }
+
+        /// Invertsion in Fp.
+        /// @notice Returns a number x such that a * x = 1 in Fp.
+        /// @notice The input does not need to be reduced.
+        /// @notice Reverts with ProofInvalid() if the inverse does not exist
+        /// @param a the input
+        /// @return x the solution
+        [Safe]
+        public static BigInteger Invert_Fp(BigInteger a)
+        {
+            BigInteger x = Exp(a, EXP_INVERSE_FP);
+            if (!MulMod(a, x, P).Equals(1))
+            {
+                throw new Exception(ProofInvalid);
+            }
+            return x;
+        }
+
+        /// Square root in Fp.
+        /// @notice Returns a number x such that x * x = a in Fp.
+        /// @notice Will revert with InvalidProof() if the input is not a square
+        /// or not reduced.
+        /// @param a the square
+        /// @return x the solution
+        [Safe]
+        public static BigInteger Sqrt_Fp(BigInteger a)
+        {
+            BigInteger x = Exp(a, EXP_SQRT_FP);
+            if (MulMod(x, x, P) != a)
+            {
+                throw new Exception(ProofInvalid);
+            }
+            return x;
+        }
+
+        /// Square test in Fp.
+        /// @notice Returns whether a number x exists such that x * x = a in Fp.
+        /// @notice Will revert with InvalidProof() if the input is not a square
+        /// or not reduced.
+        /// @param a the square
+        /// @return x the solution
+        [Safe]
+        public static bool IsSquare_Fp(BigInteger a)
+        {
+            BigInteger x = Exp(a, EXP_SQRT_FP);
+            return MulMod(x, x, P) == a;
+        }
+
+        /// Square root in Fp2.
+        /// @notice Fp2 is the complex extension Fp[i]/(i^2 + 1). The input is
+        /// a0 + a1 ⋅ i and the result is x0 + x1 ⋅ i.
+        /// @notice Will revert with InvalidProof() if
+        ///   * the input is not a square,
+        ///   * the hint is incorrect, or
+        ///   * the input coefficients are not reduced.
+        /// @param a0 The real part of the input.
+        /// @param a1 The imaginary part of the input.
+        /// @param hint A hint which of two possible signs to pick in the equation.
+        /// @return x0 The real part of the square root.
+        /// @return x1 The imaginary part of the square root.
+        [Safe]
+        public static (BigInteger x0, BigInteger x1) Sqrt_Fp2(BigInteger a0, BigInteger a1, bool hint)
+        {
+            BigInteger d = Sqrt_Fp(AddMod(MulMod(a0, a0, P), MulMod(a1, a1, P), P));
+            if (hint) d = Negate(d);
+
+            BigInteger x0 = Sqrt_Fp(MulMod(AddMod(a0, d, P), FRACTION_1_2_FP, P));
+            BigInteger x1 = MulMod(a1, Invert_Fp(MulMod(x0, 2, P)), P);
+
+            // 结果校验
+            if (a0 != AddMod(MulMod(x0, x0, P), Negate(MulMod(x1, x1, P)), P)
+                || a1 != MulMod(2, MulMod(x0, x1, P), P))
+            {
+                throw new Exception(ProofInvalid);
+            }
+            return (x0, x1);
+        }
+
+        /// Compress a G1 point.
+        /// @notice Reverts with InvalidProof if the coordinates are not reduced
+        /// or if the point is not on the curve.
+        /// @notice The point at infinity is encoded as (0,0) and compressed to 0.
+        /// @param x The X coordinate in Fp.
+        /// @param y The Y coordinate in Fp.
+        /// @return c The compresed point (x with one signal bit).
+        [Safe]
+        public static BigInteger Compress_g1(BigInteger x, BigInteger y)
+        {
+            if (x >= P || y >= P) throw new Exception(ProofInvalid);
+            if (x == 0 && y == 0) return 0;
+
+            BigInteger y_pos = Sqrt_Fp(AddMod(MulMod(MulMod(x, x, P), x, P), 3, P));
+            if (y == y_pos) return (x << 1) | 0;
+            if (y == Negate(y_pos)) return (x << 1) | 1;
+
+            throw new Exception(ProofInvalid);
+        }
+
+        /// Decompress a G1 point.
+        /// @notice Reverts with InvalidProof if the input does not represent a valid point.
+        /// @notice The point at infinity is encoded as (0,0) and compressed to 0.
+        /// @param c The compresed point (x with one signal bit).
+        /// @return x The X coordinate in Fp.
+        /// @return y The Y coordinate in Fp.
+        [Safe]
+        public static (BigInteger x, BigInteger y) Decompress_g1(BigInteger c)
+        {
+            if (c == 0) return (0, 0);
+
+            bool negatePoint = (c & 1) == 1;
+            BigInteger x = c >> 1;
+            if (x >= P) throw new Exception(ProofInvalid);
+
+            BigInteger y = Sqrt_Fp(AddMod(MulMod(MulMod(x, x, P), x, P), 3, P));
+            if (negatePoint) y = Negate(y);
+
+            return (x, y);
+        }
+
+       /// Compress a G2 point.
+        /// @notice Reverts with InvalidProof if the coefficients are not reduced
+        /// or if the point is not on the curve.
+        /// @notice The G2 curve is defined over the complex extension Fp[i]/(i^2 + 1)
+        /// with coordinates (x0 + x1 ⋅ i, y0 + y1 ⋅ i).
+        /// @notice The point at infinity is encoded as (0,0,0,0) and compressed to (0,0).
+        /// @param x0 The real part of the X coordinate.
+        /// @param x1 The imaginary poart of the X coordinate.
+        /// @param y0 The real part of the Y coordinate.
+        /// @param y1 The imaginary part of the Y coordinate.
+        /// @return c0 The first half of the compresed point (x0 with two signal bits).
+        /// @return c1 The second half of the compressed point (x1 unmodified).
+		[Safe]
+        public static (BigInteger c0,BigInteger c1) Compress_g2(BigInteger x0, BigInteger x1, BigInteger y0, BigInteger y1)
+        {
+            if (x0 >= P || x1 >= P || y0 >= P || y1 >= P)
+            {
+                // G2 point not in field.
+                throw new Exception(ProofInvalid);
+            }
+            if ((x0 | x1 | y0 | y1) == 0)
+            {
+                // Point at infinity
+                return (0, 0);
+            }
+
+            // Compute y^2
+            // Note: shadowing variables and scoping to avoid stack-to-deep.
+            BigInteger y0_pos;
+            BigInteger y1_pos;
+            {
+                BigInteger n3ab = MulMod(MulMod(x0, x1, P), P - 3, P);
+                BigInteger a_3 = MulMod(MulMod(x0, x0, P), x0, P);
+                BigInteger b_3 = MulMod(MulMod(x1, x1, P), x1, P);
+                y0_pos = AddMod(FRACTION_27_82_FP, AddMod(a_3, MulMod(n3ab, x1, P), P), P);
+                y1_pos = Negate(AddMod(FRACTION_3_82_FP, AddMod(b_3, MulMod(n3ab, x0, P), P), P));
+            }
+
+            // Determine hint bit
+            // If this sqrt fails the x coordinate is not on the curve.
+            bool hint;
+            {
+                BigInteger d = Sqrt_Fp(AddMod(MulMod(y0_pos, y0_pos, P), MulMod(y1_pos, y1_pos, P), P));
+                hint = !IsSquare_Fp(MulMod(AddMod(y0_pos, d, P), FRACTION_1_2_FP, P));
+            }
+            BigInteger c0 = 0;
+            BigInteger c1 = 0;
+            // Recover y
+            (y0_pos,y1_pos)= Sqrt_Fp2(y0_pos, y1_pos, hint);
+            if (y0 == y0_pos && y1 == y1_pos)
+            {
+                c0 = (x0 << 2) | (hint ? 2 : 0) | 0;
+                c1 = x1;
+                return (c0, c1);
+            }
+            else if (y0 == Negate(y0_pos) && y1 == Negate(y1_pos))
+            {
+                c0 = (x0 << 2) | (hint ? 2 : 0) | 1;
+                c1 = x1;
+                return (c0, c1);
+            }
+            else
+            {
+                // G1 point not on curve.
+                throw new Exception(ProofInvalid);
+            }
+        }
+
+        /// Decompress a G2 point.
+        /// @notice Reverts with InvalidProof if the input does not represent a valid point.
+        /// @notice The G2 curve is defined over the complex extension Fp[i]/(i^2 + 1)
+        /// with coordinates (x0 + x1 ⋅ i, y0 + y1 ⋅ i).
+        /// @notice The point at infinity is encoded as (0,0,0,0) and compressed to (0,0).
+        /// @param c0 The first half of the compresed point (x0 with two signal bits).
+        /// @param c1 The second half of the compressed point (x1 unmodified).
+        /// @return x0 The real part of the X coordinate.
+        /// @return x1 The imaginary poart of the X coordinate.
+        /// @return y0 The real part of the Y coordinate.
+        /// @return y1 The imaginary part of the Y coordinate.
+        [Safe]
+        public static (BigInteger x0, BigInteger x1, BigInteger y0, BigInteger y1)  Decompress_g2(BigInteger c0, BigInteger c1)
+        {
+            // Note that X = (0, 0) is not on the curve since 0³ + 3/(9 + i) is not a square.
+            // so we can use it to represent the point at infinity.
+            if (c0 == 0 && c1 == 0)
+            {
+                // Point at infinity as encoded in EIP197.
+                return (0, 0, 0, 0);
+            }
+            bool negate_point = (c0 & 1) == 1;
+            bool hint = (c0 & 2) == 2;
+            BigInteger x0 = c0 >> 2;
+            BigInteger x1 = c1;
+            if (x0 >= P || x1 >= P)
+            {
+                // G2 x0 or x1 coefficient not in field.
+                throw new Exception(ProofInvalid);
+            }
+
+            BigInteger n3ab = MulMod(MulMod(x0, x1, P), P - 3, P);
+            BigInteger a_3 = MulMod(MulMod(x0, x0, P), x0, P);
+            BigInteger b_3 = MulMod(MulMod(x1, x1, P), x1, P);
+
+            BigInteger y0 = AddMod(FRACTION_27_82_FP, AddMod(a_3, MulMod(n3ab, x1, P), P), P);
+            BigInteger y1 = Negate(AddMod(FRACTION_3_82_FP, AddMod(b_3, MulMod(n3ab, x0, P), P), P));
+
+            // Note: sqrt_Fp2 reverts if there is no solution, i.e. the point is not on the curve.
+            // Note: (X³ + 3/(9 + i)) is irreducible in Fp2, so y can not be zero.
+            //       But y0 or y1 may still independently be zero.
+            (y0,y1)= Sqrt_Fp2(y0, y1, hint);
+            if (negate_point)
+            {
+                y0 = Negate(y0);
+                y1 = Negate(y1);
+            }
+            return (x0,  x1, y0, y1);
+        }
+    }
+}
+`
+
+// MarshalN3Contract converts a proof to a byte array that can be used in a
+// n3 contract.
+func (proof *Proof) MarshalN3Contract() []byte {
+	var buf bytes.Buffer
+	_, err := proof.WriteRawTo(&buf)
+	if err != nil {
+		panic(err)
+	}
+
+	// If there are no commitments, we can return only Ar | Bs | Krs
+	if len(proof.Commitments) > 0 {
+		return buf.Bytes()
+	} else {
+		return buf.Bytes()[:8*fr.Bytes]
+	}
+}

--- a/backend/groth16/bn254/verify.go
+++ b/backend/groth16/bn254/verify.go
@@ -229,3 +229,95 @@ func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.Expor
 
 	return err
 }
+
+// ExportN3Contract writes a n3 Verifier contract on provided writer.
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	cfg, err := solidity.NewExportConfig(exportOpts...)
+	log := logger.Logger()
+	if err != nil {
+		return err
+	}
+	if cfg.HashToFieldFn == nil {
+		// set the target hash function to legacy keccak256 as it is the default for `solidity.WithTargetSolidityVerifier``
+		cfg.HashToFieldFn = sha3.NewLegacyKeccak256()
+		log.Debug().Msg("hash to field function not set, using keccak256 as default")
+	}
+	// a bit hacky way to understand what hash function is provided. We already
+	// receive instance of hash function but it is difficult to compare it with
+	// sha256.New() or sha3.NewLegacyKeccak256() directly.
+	//
+	// So, we hash an empty input and compare the outputs.
+	cfg.HashToFieldFn.Reset()
+	hashBts := cfg.HashToFieldFn.Sum(nil)
+	var hashFnName string
+	if bytes.Equal(hashBts, sha256.New().Sum(nil)) {
+		hashFnName = "sha256"
+	} else if bytes.Equal(hashBts, sha3.NewLegacyKeccak256().Sum(nil)) {
+		hashFnName = "keccak256"
+	} else {
+		return fmt.Errorf("unsupported hash function used, only supported sha256 and legacy keccak256")
+	}
+	cfg.HashToFieldFn.Reset()
+	helpers := template.FuncMap{
+		"sum": func(a, b int) int {
+			return a + b
+		},
+		"sub": func(a, b int) int {
+			return a - b
+		},
+		"mul": func(a, b int) int {
+			return a * b
+		},
+		"intRange": func(max int) []int {
+			out := make([]int, max)
+			for i := 0; i < max; i++ {
+				out[i] = i
+			}
+			return out
+		},
+		"fpstr": func(x fp.Element) string {
+			bv := new(big.Int)
+			x.BigInt(bv)
+			return bv.String()
+		},
+		"hashFnName": func() string {
+			return hashFnName
+		}, // may be used in future (verifyCompressedProof, verifyProof)
+	}
+
+	if len(vk.PublicAndCommitmentCommitted) > 1 {
+		log.Warn().Msg("exporting solidity verifier with more than one commitment is not supported")
+	} else if len(vk.PublicAndCommitmentCommitted) == 1 {
+		log.Warn().Msg("exporting solidity verifier only supports `sha256` as `HashToField`. The generated contract may not work for proofs generated with other hash functions.")
+	}
+
+	tmpl, err := template.New("").Funcs(helpers).Parse(n3ContractTemplate)
+	if err != nil {
+		return err
+	}
+
+	// negate Beta, Gamma and Delta, to avoid negating proof elements in the verifier
+	var betaNeg curve.G2Affine
+	betaNeg.Neg(&vk.G2.Beta)
+	beta := vk.G2.Beta
+	vk.G2.Beta = betaNeg
+	vk.G2.Gamma, vk.G2.gammaNeg = vk.G2.gammaNeg, vk.G2.Gamma
+	vk.G2.Delta, vk.G2.deltaNeg = vk.G2.deltaNeg, vk.G2.Delta
+
+	// execute template
+	err = tmpl.Execute(w, struct {
+		Cfg solidity.ExportConfig
+		Vk  VerifyingKey
+	}{
+		Cfg: cfg,
+		Vk:  *vk,
+	})
+
+	// restore Beta, Gamma and Delta
+	vk.G2.Beta = beta
+	vk.G2.Gamma, vk.G2.gammaNeg = vk.G2.gammaNeg, vk.G2.Gamma
+	vk.G2.Delta, vk.G2.deltaNeg = vk.G2.deltaNeg, vk.G2.Delta
+
+	return err
+
+}

--- a/backend/groth16/bw6-633/verify.go
+++ b/backend/groth16/bw6-633/verify.go
@@ -133,3 +133,7 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }
+
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/groth16/bw6-761/verify.go
+++ b/backend/groth16/bw6-761/verify.go
@@ -133,3 +133,7 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }
+
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/groth16/groth16.go
+++ b/backend/groth16/groth16.go
@@ -9,6 +9,7 @@
 package groth16
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/consensys/gnark-crypto/ecc"
@@ -166,6 +167,54 @@ func Verify(proof Proof, vk VerifyingKey, publicWitness witness.Witness, opts ..
 			return witness.ErrInvalidWitness
 		}
 		return groth16_bw6633.Verify(_proof, vk.(*groth16_bw6633.VerifyingKey), w, opts...)
+	default:
+		panic("unrecognized R1CS curve type")
+	}
+}
+
+func Solve(r1cs constraint.ConstraintSystem, pk ProvingKey, fullWitness witness.Witness, opts ...backend.ProverOption) (any, error) {
+	switch _r1cs := r1cs.(type) {
+	case *cs_bls12377.R1CS:
+		return groth16_bls12377.Solve(_r1cs, pk.(*groth16_bls12377.ProvingKey), fullWitness, opts...)
+	case *cs_bls12381.R1CS:
+		return groth16_bls12381.Solve(_r1cs, pk.(*groth16_bls12381.ProvingKey), fullWitness, opts...)
+	case *cs_bn254.R1CS:
+		if icicle_bn254.HasIcicle {
+			return nil, fmt.Errorf("bn254 icicle has not impl solve")
+		}
+		return groth16_bn254.Solve(_r1cs, pk.(*groth16_bn254.ProvingKey), fullWitness, opts...)
+	case *cs_bw6761.R1CS:
+		return groth16_bw6761.Solve(_r1cs, pk.(*groth16_bw6761.ProvingKey), fullWitness, opts...)
+	case *cs_bls24317.R1CS:
+		return groth16_bls24317.Solve(_r1cs, pk.(*groth16_bls24317.ProvingKey), fullWitness, opts...)
+	case *cs_bls24315.R1CS:
+		return groth16_bls24315.Solve(_r1cs, pk.(*groth16_bls24315.ProvingKey), fullWitness, opts...)
+	case *cs_bw6633.R1CS:
+		return groth16_bw6633.Solve(_r1cs, pk.(*groth16_bw6633.ProvingKey), fullWitness, opts...)
+	default:
+		panic("unrecognized R1CS curve type")
+	}
+}
+
+func ProofComputing(solveResult any, pk ProvingKey) (Proof, error) {
+	switch solveResult.(type) {
+	case *groth16_bls12377.SolveResult:
+		return groth16_bls12377.ProofComputing(solveResult.(*groth16_bls12377.SolveResult), pk.(*groth16_bls12377.ProvingKey))
+	case *groth16_bls12381.SolveResult:
+		return groth16_bls12381.ProofComputing(solveResult.(*groth16_bls12381.SolveResult), pk.(*groth16_bls12381.ProvingKey))
+	case *groth16_bn254.SolveResult:
+		if icicle_bn254.HasIcicle {
+			return nil, fmt.Errorf("bn254 icicle has not impl solve")
+		}
+		return groth16_bn254.ProofComputing(solveResult.(*groth16_bn254.SolveResult), pk.(*groth16_bn254.ProvingKey))
+	case *groth16_bw6761.SolveResult:
+		return groth16_bw6761.ProofComputing(solveResult.(*groth16_bw6761.SolveResult), pk.(*groth16_bw6761.ProvingKey))
+	case *groth16_bls24317.SolveResult:
+		return groth16_bls24317.ProofComputing(solveResult.(*groth16_bls24317.SolveResult), pk.(*groth16_bls24317.ProvingKey))
+	case *groth16_bls24315.SolveResult:
+		return groth16_bls24315.ProofComputing(solveResult.(*groth16_bls24315.SolveResult), pk.(*groth16_bls24315.ProvingKey))
+	case *groth16_bw6633.SolveResult:
+		return groth16_bw6633.ProofComputing(solveResult.(*groth16_bw6633.SolveResult), pk.(*groth16_bw6633.ProvingKey))
 	default:
 		panic("unrecognized R1CS curve type")
 	}

--- a/backend/plonk/bls12-377/verify.go
+++ b/backend/plonk/bls12-377/verify.go
@@ -386,3 +386,7 @@ func deriveRandomness(fs *fiatshamir.Transcript, challenge string, points ...*cu
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }
+
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/plonk/bls12-381/verify.go
+++ b/backend/plonk/bls12-381/verify.go
@@ -386,3 +386,6 @@ func deriveRandomness(fs *fiatshamir.Transcript, challenge string, points ...*cu
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/plonk/bls24-315/verify.go
+++ b/backend/plonk/bls24-315/verify.go
@@ -386,3 +386,7 @@ func deriveRandomness(fs *fiatshamir.Transcript, challenge string, points ...*cu
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }
+
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/plonk/bls24-317/verify.go
+++ b/backend/plonk/bls24-317/verify.go
@@ -386,3 +386,6 @@ func deriveRandomness(fs *fiatshamir.Transcript, challenge string, points ...*cu
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/plonk/bn254/n3_contract.go
+++ b/backend/plonk/bn254/n3_contract.go
@@ -1,0 +1,11 @@
+package plonk
+
+import (
+	"errors"
+	"github.com/consensys/gnark/backend/solidity"
+	"io"
+)
+
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/plonk/bw6-633/verify.go
+++ b/backend/plonk/bw6-633/verify.go
@@ -121,11 +121,11 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 	one := fr.One()
 	bExpo.SetUint64(vk.Size)
 	zetaPowerM.Exp(zeta, &bExpo)
-	zhZeta.Sub(&zetaPowerM, &one)  // ζⁿ-1
+	zhZeta.Sub(&zetaPowerM, &one) // ζⁿ-1
 	lagrangeZero.Sub(&zeta, &one). // ζ-1
-					Inverse(&lagrangeZero).         // 1/(ζ-1)
-					Mul(&lagrangeZero, &zhZeta).    // (ζ^n-1)/(ζ-1)
-					Mul(&lagrangeZero, &vk.SizeInv) // 1/n * (ζ^n-1)/(ζ-1)
+		Inverse(&lagrangeZero). // 1/(ζ-1)
+		Mul(&lagrangeZero, &zhZeta). // (ζ^n-1)/(ζ-1)
+		Mul(&lagrangeZero, &vk.SizeInv) // 1/n * (ζ^n-1)/(ζ-1)
 
 	// compute PI = ∑_{i<n} Lᵢ*wᵢ
 	var pi fr.Element
@@ -173,9 +173,9 @@ func Verify(proof *Proof, vk *VerifyingKey, publicWitness fr.Vector, opts ...bac
 			den.Sub(&zeta, &wPowI) // ζ-wⁱ
 			lagrange.SetOne().
 				Sub(&zetaPowerM, &lagrange). // ζⁿ-1
-				Mul(&lagrange, &wPowI).      // wⁱ(ζⁿ-1)
-				Div(&lagrange, &den).        // wⁱ(ζⁿ-1)/(ζ-wⁱ)
-				Mul(&lagrange, &vk.SizeInv)  // wⁱ/n (ζⁿ-1)/(ζ-wⁱ)
+				Mul(&lagrange, &wPowI). // wⁱ(ζⁿ-1)
+				Div(&lagrange, &den). // wⁱ(ζⁿ-1)/(ζ-wⁱ)
+				Mul(&lagrange, &vk.SizeInv) // wⁱ/n (ζⁿ-1)/(ζ-wⁱ)
 
 			xiLi.Mul(&lagrange, &hashedCmt)
 			pi.Add(&pi, &xiLi)
@@ -384,5 +384,9 @@ func deriveRandomness(fs *fiatshamir.Transcript, challenge string, points ...*cu
 
 // ExportSolidity not implemented for BW6-633
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}
+
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }

--- a/backend/plonk/bw6-761/verify.go
+++ b/backend/plonk/bw6-761/verify.go
@@ -386,3 +386,7 @@ func deriveRandomness(fs *fiatshamir.Transcript, challenge string, points ...*cu
 func (vk *VerifyingKey) ExportSolidity(w io.Writer, exportOpts ...solidity.ExportOption) error {
 	return errors.New("not implemented")
 }
+
+func (vk *VerifyingKey) ExportN3Contract(w io.Writer, exportOpts ...solidity.ExportOption) error {
+	return errors.New("not implemented")
+}

--- a/backend/solidity/verifyingkey.go
+++ b/backend/solidity/verifyingkey.go
@@ -6,4 +6,5 @@ import "io"
 type VerifyingKey interface {
 	NbPublicWitness() int
 	ExportSolidity(io.Writer, ...ExportOption) error
+	ExportN3Contract(io.Writer, ...ExportOption) error // export n3 contract
 }


### PR DESCRIPTION
In order to automatically export N3 contracts from VerifiingKey, the ExportN3Contract() function was added to the interface of VerifiingKey. Currently, only the bn254 curve of groth16 has been implemented. Among them, the other curves of groth16 have not been officially implemented with corresponding ExportSolidity() by gnark, and the same is true for other curves of plonk. The N3 template for plonk's bn254 curve has not been implemented yet, so it also returns 'not implemented'.